### PR TITLE
Fix random panics when running tests

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -53,9 +53,12 @@ func TestPrivateMessage(t *testing.T) {
 				t.Fatalf("got %q, expected %q, case %q", err, c.E, num)
 			}
 
+			// No request was created so the test has been completed and
+			// we won't check the request body, as there is none.
 			return
 		}
 
+		// Check the request body matches our expectation
 		body, _ := ioutil.ReadAll(bot.Client.(*testClient).Request.Body)
 		if string(body) != c.Body {
 			t.Errorf("got %q, expected %q, case %q", string(body), c.Body, num)

--- a/message_test.go
+++ b/message_test.go
@@ -32,11 +32,6 @@ func TestPrivateMessage(t *testing.T) {
 		// ignore response from testClient
 		_, err := bot.PrivateMessage(c.M)
 
-		// no error expected
-		if err != nil && c.E == nil {
-			t.Fatalf("got %q, expected nil, case %q", err, num)
-		}
-
 		// Check if error matches the error specified in the case
 		switch c.E {
 		case nil:

--- a/message_test.go
+++ b/message_test.go
@@ -32,20 +32,33 @@ func TestPrivateMessage(t *testing.T) {
 		// ignore response from testClient
 		_, err := bot.PrivateMessage(c.M)
 
+		// no error expected
+		if err != nil && c.E == nil {
+			t.Fatalf("got %q, expected nil, case %q", err, num)
+		}
+
+		// Check if error matches the error specified in the case
+		switch c.E {
+		case nil:
+			if err != nil && c.E == nil {
+				t.Fatalf("got %q, expected nil, case %q", err, num)
+			}
+
+		default:
+			if err == nil {
+				t.Fatalf("got nil, expected %q, case %q", err, c.E, num)
+			}
+
+			if err.Error() != c.E.Error() {
+				t.Fatalf("got %q, expected %q, case %q", err, c.E, num)
+			}
+
+			return
+		}
+
 		body, _ := ioutil.ReadAll(bot.Client.(*testClient).Request.Body)
 		if string(body) != c.Body {
 			t.Errorf("got %q, expected %q, case %q", string(body), c.Body, num)
-		}
-
-		// no error expected
-		if c.E == nil && err != nil {
-			t.Errorf("got %q, expected nil, case %q", err, num)
-		}
-		// error expected, prevent nil.Error() panic
-		if c.E != nil && err == nil {
-			t.Errorf("got nil, expected %q, case %q", err, c.E, num)
-		} else if c.E != nil && err.Error() != c.E.Error() {
-			t.Errorf("got %q, expected %q, case %q", err, c.E, num)
 		}
 	}
 }


### PR DESCRIPTION
The issue was when you were specifying that there would be an error return you were still reading into the http's Body which wouldn't exist because the Message wasn't formatted correctly. To fix this I broke out the logic tree of the test expectations to ensure that the Body isn't read when the case has an error specified as the return.

The reason it was happening only part of the time must have been because of a race condition of some sort.
